### PR TITLE
use size_t for nbRegions and nbCells, so not automatically converting…

### DIFF
--- a/src/place_detailed/place_detailed.cpp
+++ b/src/place_detailed/place_detailed.cpp
@@ -551,12 +551,12 @@ class RowReordering {
   /**
    * @brief Number of registered regions
    */
-  int nbRegions() const { return regions_.size(); }
+  size_t nbRegions() const { return regions_.size(); }
 
   /**
    * @brief Number of registered cells
    */
-  int nbCells() const { return cells_.size(); }
+  size_t nbCells() const { return cells_.size(); }
 
   /**
    * @brief Add a region and its cells to be optimized


### PR DESCRIPTION
Fixes compiler warnings found when using -pedantic